### PR TITLE
Sync pricing-script types v1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infigo-official/types-for-pricing-script",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Type definitions for Pricing Script Scripting",
   "types": "v1/index.d.ts",
   "devDependencies": {

--- a/v1/File/FileInfo.d.ts
+++ b/v1/File/FileInfo.d.ts
@@ -134,6 +134,22 @@ declare interface FileInfo {
     Content: string[];
 
     /**
+     * The parsed CSV content of the file as a 2D array of strings (rows by columns).
+     * Only set when the file is a CSV/text file read with the readContent flag enabled;
+     * the first row typically contains the column headers. Absent for non-CSV files.
+     *
+     * @example
+     * var fileInfo = Item.getFileInfo("dataFile", true);
+     * if (fileInfo && fileInfo.CsvContent) {
+     *     var headers = fileInfo.CsvContent[0];
+     *     for (var i = 1; i < fileInfo.CsvContent.length; i++) {
+     *         var row = fileInfo.CsvContent[i];
+     *     }
+     * }
+     */
+    CsvContent: string[][];
+
+    /**
      * Error message indicating any issues encountered during file processing.
      * This value is empty if retrieving file information was successful.
      * Used for error handling and debugging file processing issues.

--- a/v1/OrderItem/Item.d.ts
+++ b/v1/OrderItem/Item.d.ts
@@ -428,6 +428,20 @@ declare interface Item {
     Department: string;
 
     /**
+     * The cost code of the customer's department, if the customer belongs to one.
+     * Empty when the customer has no department, or the department has no cost code set.
+     * Useful for cost-centre-based pricing rules or for tagging the calculated price.
+     *
+     * @example
+     * // Apply cost-centre-specific pricing
+     * if (Item.DepartmentCostCode === "CC-100") {
+     *     debug("Cost centre CC-100 order");
+     *     return Item.Price * 0.90; // 10% discount for cost centre CC-100
+     * }
+     */
+    DepartmentCostCode: string;
+
+    /**
      * Array of other order items using the same custom pricing script
      *
      * @example

--- a/v1/SessionItem/Session.d.ts
+++ b/v1/SessionItem/Session.d.ts
@@ -84,6 +84,31 @@ declare interface Session {
      * }
      */
     Department: string;
+
+    /**
+     * Cost code of the customer's department for the current session.
+     * Empty when the customer has no department, or the department has no cost code set.
+     * Used for cost-centre-based session pricing and business logic.
+     *
+     * @example
+     * console("Customer department cost code: " + Session.DepartmentCostCode);
+     * if (Session.DepartmentCostCode === "CC-100") {
+     *     console("Cost centre CC-100 - apply centre-specific pricing");
+     * }
+     */
+    DepartmentCostCode: string;
+
+    /**
+     * Value of the discount code currently applied in the session.
+     * Reflects the discount coupon code entered by the customer, if any.
+     * Used to apply code-specific pricing or promotions at the session level.
+     *
+     * @example
+     * if (Session.DiscountCode === "SUMMER20") {
+     *     console("Summer discount code applied in session");
+     * }
+     */
+    DiscountCode: string;
 }
 
 /**


### PR DESCRIPTION
Syncs newly-exposed public members of the pricing-script item classes (C# source of truth in the catfish repo) into the type definitions.

## Added
| Member | Type | Target | Source C# |
|---|---|---|---|
| `DepartmentCostCode` | `string` | `v1/OrderItem/Item.d.ts` | `BaseCheckoutItem` |
| `DepartmentCostCode` | `string` | `v1/SessionItem/Session.d.ts` | `BaseCheckoutItem` |
| `DiscountCode` | `string` | `v1/SessionItem/Session.d.ts` | `BaseCheckoutItem` (pre-existing gap; already in Item) |
| `CsvContent` | `string[][]` | `v1/File/FileInfo.d.ts` | `OrderItem.FileInfo` (pre-existing gap) |

`DepartmentCostCode` is the newly added property; `DiscountCode` (Session) and `CsvContent` (FileInfo) were pre-existing omissions surfaced by the same sync.

## Version
Bumps `1.0.7` -> `1.0.8`. Merging to `main` triggers `DocGeneration.yml`, which publishes the new version to npm + GitHub Packages.

Generated by the catfish `/sync-pricing-script-types` command.